### PR TITLE
Add prelude module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -528,6 +528,18 @@ macro_rules! scenario {
     };
 }
 
+/// Common imports for working with madhouse scenarios.
+///
+/// Import everything needed for scenario testing with a single use statement:
+/// ```
+/// use madhouse::prelude::*;
+/// ```
+pub mod prelude {
+    pub use crate::{
+        execute_commands, prop_allof, scenario, Command, CommandWrapper, State, TestContext,
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This PR adds a prelude module to simplify imports when using the scenario macro. Users no longer need to manually import `Command`, `execute_commands`, and `prop_allof` – they can now use `madhouse::prelude::*`.