### PR TITLE
Allow `scenario` macro to take command instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ impl Command<Counter, Ctx> for Reset {
 
 fn main() {
     let ctx = Arc::new(Ctx::default());
-    scenario![ctx, Inc, Reset];
+    scenario![ctx, Inc, Reset, (Inc { amount: 42 })];
 }
 ```
 


### PR DESCRIPTION
Commands in scenario! can now be passed as expressions, not just types. This allows writing things like:

    scenario![ctx, Inc, Reset, (Inc { amount: 3 })];

Wrapped expressions are matched as concrete values using `Just`.

The core trick is that macro_rules! can't match `{}` inside a :tt unless wrapped in parens. We match inputs using a helper arm:
- Identifiers call build(ctx)
- Expressions are turned into Just(CommandWrapper::new(...))

This keeps the macro simple and readable while adding real flexibility.

Thanks to @fdefelici for pointing this out.

See also:
https://doc.rust-lang.org/reference/macros-by-example.html#metavariables
