### PR TITLE
Allow any `proptest` version matching `1.6.*`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.1"
 edition = "2021"
 
 [dependencies]
-proptest = { git = "https://github.com/proptest-rs/proptest.git", rev = "c9bdf18c232665b2b740c667c81866b598d06dc7" }
+proptest = "1.6.*"


### PR DESCRIPTION
This PR removes the unnecessary `proptest` strict commit hash enforcement.