### PR TITLE
Document and add interactive playground script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,64 +27,89 @@ Tests state machines via sequences of command objects. Each command:
   +----------+
 ```
 
+## Features
+
+- Trait-based command design
+- Self-validating commands
+- Timing information
+- Test case shrinking
+
 ## Usage
 
 ```rust
-use madhouse::*;
+use madhouse::prelude::*;
 use proptest::prelude::*;
-use std::env;
 use std::sync::Arc;
 
-// State + Context
 #[derive(Debug, Default)]
 struct Counter {
     value: u32,
-    max: u32,
 }
 impl State for Counter {}
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Debug, Default)]
 struct Ctx {}
 impl TestContext for Ctx {}
 
-// Commands
-struct Inc {
+struct Increment {
     amount: u32,
 }
-impl Command<Counter, Ctx> for Inc {
-    fn check(&self, s: &Counter) -> bool {
-        s.value + self.amount <= s.max
+impl Command<Counter, Ctx> for Increment {
+    fn check(&self, _: &Counter) -> bool {
+        true
     }
-    fn apply(&self, s: &mut Counter) {
-        s.value += self.amount;
+
+    fn apply(&self, state: &mut Counter) {
+        state.value += self.amount;
+        assert!(
+            state.value <= 100,
+            "Counter value exceeded maximum allowed: {}",
+            state.value
+        );
     }
+
     fn label(&self) -> String {
-        format!("INC({})", self.amount)
+        format!("INCREMENT({})", self.amount)
     }
-    fn build(_: Arc<Ctx>) -> impl Strategy<Value = CommandWrapper<Counter, Ctx>> {
-        (1..=5u32).prop_map(|n| CommandWrapper::new(Inc { amount: n }))
+
+    fn build(_: Arc<Ctx>)
+        -> impl Strategy<Value = CommandWrapper<Counter, Ctx>>
+    {
+        (1..=50u32).prop_map(|amount| {
+            CommandWrapper::new(Increment { amount })
+        })
     }
 }
 
-struct Reset;
-impl Command<Counter, Ctx> for Reset {
-    fn check(&self, s: &Counter) -> bool {
-        s.value > 0
+struct Decrement {
+    amount: u32,
+}
+impl Command<Counter, Ctx> for Decrement {
+    fn check(&self, state: &Counter) -> bool {
+        state.value >= self.amount
     }
-    fn apply(&self, s: &mut Counter) {
-        s.value = 0;
+
+    fn apply(&self, state: &mut Counter) {
+        state.value -= self.amount;
     }
+
     fn label(&self) -> String {
-        "RESET".to_string()
+        format!("DECREMENT({})", self.amount)
     }
-    fn build(_: Arc<Ctx>) -> impl Strategy<Value = CommandWrapper<Counter, Ctx>> {
-        Just(CommandWrapper::new(Reset))
+
+    fn build(_: Arc<Ctx>)
+        -> impl Strategy<Value = CommandWrapper<Counter, Ctx>>
+    {
+        (1..=10u32).prop_map(|amount| {
+            CommandWrapper::new(Decrement { amount })
+        })
     }
 }
 
-fn main() {
+#[test]
+fn test_counter() {
     let ctx = Arc::new(Ctx::default());
-    scenario![ctx, Inc, Reset, (Inc { amount: 42 })];
+    scenario![ctx, Increment, Decrement, (Increment { amount: 42 })];
 }
 ```
 
@@ -94,9 +119,12 @@ fn main() {
 - **Random**: Commands chosen pseudorandomly (set `MADHOUSE=1`)
 - **Shrinking**: To shrink test cases, set `PROPTEST_MAX_SHRINK_ITERS`
 
-## Example
+## Examples
 
-Run tests:
+### Basic Usage
+
+Run tests on your own projects:
+
 ```bash
 # Normal mode
 cargo test
@@ -105,15 +133,28 @@ cargo test
 MADHOUSE=1 cargo test
 
 # With shrinking
-MADHOUSE=1 PROPTEST_MAX_SHRINK_ITERS=100 cargo test
+MADHOUSE=1 PROPTEST_MAX_SHRINK_ITERS=50 cargo test
 ```
 
-## Features
+### Interactive Playground
 
-- Trait-based command design
-- Self-validating commands
-- Timing information
-- Test case shrinking
+Try the [playground script](scripts/playground.sh) for a hands-on demo.
+
+```bash
+# Normal mode
+./scripts/playground.sh
+
+# Random mode
+MADHOUSE=1 ./scripts/playground.sh
+
+# With shrinking
+MADHOUSE=1 PROPTEST_MAX_SHRINK_ITERS=50 ./scripts/playground.sh
+```
+
+The playground script:
+- Creates a sample counter project with increment/decrement commands
+- Demonstrates test failure detection and preservation
+- Shows how shrinking works to find minimal failing test cases
 
 ## License
 

--- a/scripts/playground.sh
+++ b/scripts/playground.sh
@@ -1,0 +1,131 @@
+#!/bin/sh
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Go up one directory to check if we're in the madhouse repository. We
+# assume the script is in the scripts/ subdirectory of the repository.
+# This may not be the case if script was copied elsewhere for testing.
+# This is to verify the directory structure, before using local paths.
+SOURCE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Create a temp directory for our test project.
+tmp=$(mktemp -d /tmp/play-XXXXXXXX)
+echo "Using temp dir: $tmp"
+
+cleanup() {
+    if [ $? -ne 0 ]; then
+        echo
+        echo "Test failed. Temp project preserved at:"
+        echo "  $tmp"
+    else
+        rm -rf "$tmp"
+    fi
+}
+trap cleanup EXIT
+
+# Create the test project.
+cargo new --lib "$tmp/counter" >/dev/null
+cd "$tmp/counter"
+
+# Check if this appears to be the madhouse repository.
+TOML="$SOURCE_DIR/Cargo.toml"
+if [ -f "$TOML" ] && grep -q "name.*madhouse" "$TOML"; then
+    echo "✅ Running from within madhouse repository"
+    MADHOUSE_DEP="madhouse = { path = \"$SOURCE_DIR\" }"
+else
+    echo "ℹ️ Running outside madhouse repository - using git dependency"
+    MADHOUSE_DEP="madhouse = { git = \
+      \"https://github.com/stacks-network/madhouse-rs.git\" }"
+fi
+
+# Create Cargo.toml with dependencies.
+cat > Cargo.toml <<EOF
+[package]
+name = "counter"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+$MADHOUSE_DEP
+proptest = "1.6.*"
+EOF
+
+# Create test file with example.
+cat > src/lib.rs <<'EOF'
+use madhouse::prelude::*;
+use proptest::prelude::*;
+use std::sync::Arc;
+
+#[derive(Debug, Default)]
+struct Counter {
+    value: u32,
+}
+impl State for Counter {}
+
+#[derive(Clone, Debug, Default)]
+struct Ctx {}
+impl TestContext for Ctx {}
+
+struct Increment {
+    amount: u32,
+}
+impl Command<Counter, Ctx> for Increment {
+    fn check(&self, _: &Counter) -> bool {
+        true
+    }
+
+    fn apply(&self, state: &mut Counter) {
+        state.value += self.amount;
+        assert!(
+            state.value <= 100,
+            "Counter value exceeded maximum allowed: {}",
+            state.value
+        );
+    }
+
+    fn label(&self) -> String {
+        format!("INCREMENT({})", self.amount)
+    }
+
+    fn build(_: Arc<Ctx>)
+        -> impl Strategy<Value = CommandWrapper<Counter, Ctx>>
+    {
+        (1..=50u32).prop_map(|amount| {
+            CommandWrapper::new(Increment { amount })
+        })
+    }
+}
+
+struct Decrement {
+    amount: u32,
+}
+impl Command<Counter, Ctx> for Decrement {
+    fn check(&self, state: &Counter) -> bool {
+        state.value >= self.amount
+    }
+
+    fn apply(&self, state: &mut Counter) {
+        state.value -= self.amount;
+    }
+
+    fn label(&self) -> String {
+        format!("DECREMENT({})", self.amount)
+    }
+
+    fn build(_: Arc<Ctx>)
+        -> impl Strategy<Value = CommandWrapper<Counter, Ctx>>
+    {
+        (1..=10u32).prop_map(|amount| {
+            CommandWrapper::new(Decrement { amount })
+        })
+    }
+}
+
+#[test]
+fn test_counter() {
+    let ctx = Arc::new(Ctx::default());
+    scenario![ctx, Increment, Decrement, (Increment { amount: 42 })];
+}
+EOF
+
+"$@" cargo test -- --nocapture


### PR DESCRIPTION
Add playground script for hands-on testing. Script sets up a temp project
using madhouse. Uses local path if in repo, git otherwise.

README updated with link and usage example. Shows how to run tests,
trigger failures, and shrink failing cases.